### PR TITLE
Remove double main entry and add ignore

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "angular-backtop",
   "version": "0.0.5",
-  "main": "dist/angular-backtop.js",
   "main": [
     "./dist/angular-backtop.js",
     "./dist/angular-backtop.css"
@@ -12,5 +11,14 @@
   "devDependencies": {
     "angular-mocks": "~1.3.15",
     "angular-scenario": "~1.3.15"
-  }
+  },
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "libs",
+    "test",
+    "karma.conf.js",
+    "Gruntfile",
+    "package.json"
+  ]
 }


### PR DESCRIPTION
Indeed you already have the bower file :+1:  The only thing missing for the awesome to be complete is to create a tag with the version number as a name (either 'v0.0.5' or '0.0.5').

Here is two modifications proposal to the bower.json:
- I think you cannot have 'main' attribute listed twice so I propose to remove one
- I suggest to add an ignore key, this way only important files are installed by bower. Here I kept the src folder, the demo folder but removed the test.

I noticed that you use less for the styles. Maybe it makes sense to add it to the main file list in order for people that use less to import it using main-bower-file or wiredep for example. But that would be another pull request as you might want to have it in dist folder as well in this case.

Should I change something?
